### PR TITLE
[codex] Fix Renovate security alerts and Nodemailer vulnerability

### DIFF
--- a/app/admin/signups/page.tsx
+++ b/app/admin/signups/page.tsx
@@ -54,7 +54,29 @@ export default function SignupsPage() {
   };
 
   useEffect(() => {
-    fetchEvents();
+    const controller = new AbortController();
+    let active = true;
+    fetch("/api/admin/signups", { signal: controller.signal })
+      .then((response) => {
+        if (!response.ok) throw new Error("Failed to fetch events");
+        return response.json();
+      })
+      .then((data) => {
+        if (active) setEvents(data);
+      })
+      .catch((error) => {
+        if (error.name !== "AbortError") {
+          console.error("Failed to fetch events:", error);
+        }
+      })
+      .finally(() => {
+        if (active) setIsLoading(false);
+      });
+
+    return () => {
+      active = false;
+      controller.abort();
+    };
   }, []);
 
   const downloadCsv = async (eventId: string, eventTitle: string) => {

--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
         "next": "^16.2.6",
         "next-themes": "^0.4.6",
         "node-fetch": "^3.3.2",
-        "nodemailer": "^8.0.4",
+        "nodemailer": "^9.0.1",
         "pg": "^8.21.0",
         "react": "^19.2.6",
         "react-day-picker": "^9.14.0",
@@ -1092,7 +1092,7 @@
 
     "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
 
-    "nodemailer": ["nodemailer@8.0.4", "", {}, "sha512-k+jf6N8PfQJ0Fe8ZhJlgqU5qJU44Lpvp2yvidH3vp1lPnVQMgi4yEEMPXg5eJS1gFIJTVq1NHBk7Ia9ARdSBdQ=="],
+    "nodemailer": ["nodemailer@9.0.1", "", {}, "sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 

--- a/components/admin/EventList.tsx
+++ b/components/admin/EventList.tsx
@@ -70,10 +70,6 @@ export function EventList() {
   const [showEditDialog, setShowEditDialog] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
-  useEffect(() => {
-    fetchEvents();
-  }, []);
-
   const fetchEvents = async () => {
     try {
       const response = await fetch("/api/admin/events");
@@ -95,6 +91,41 @@ export function EventList() {
       setIsLoading(false);
     }
   };
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let active = true;
+    fetch("/api/admin/events", { signal: controller.signal })
+      .then((response) => response.json())
+      .then((data: EventResponse[]) => {
+        if (active) {
+          setEvents(
+          data.map((event) => ({
+            ...event,
+            startDate: new Date(event.startDate),
+            endDate: event.endDate ? new Date(event.endDate) : undefined,
+            signupPeriodJson: event.signup_period_json || {
+              startDate: null,
+              endDate: null,
+            },
+            }))
+          );
+        }
+      })
+      .catch((error) => {
+        if (error.name !== "AbortError") {
+          console.error("Failed to fetch events:", error);
+        }
+      })
+      .finally(() => {
+        if (active) setIsLoading(false);
+      });
+
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, []);
 
   const deleteEvent = async (eventId: string) => {
     try {

--- a/components/admin/EventSignupsList.tsx
+++ b/components/admin/EventSignupsList.tsx
@@ -72,8 +72,30 @@ export function EventSignupsList({
   }, [eventId]);
 
   useEffect(() => {
-    fetchSignups();
-  }, [fetchSignups]);
+    const controller = new AbortController();
+    let active = true;
+    fetch(`/api/admin/signups/${eventId}`, { signal: controller.signal })
+      .then((response) => {
+        if (!response.ok) throw new Error("Failed to fetch signups");
+        return response.json();
+      })
+      .then((data) => {
+        if (active) setSignups(data);
+      })
+      .catch((error) => {
+        if (error.name !== "AbortError") {
+          console.error("Failed to fetch signups:", error);
+        }
+      })
+      .finally(() => {
+        if (active) setIsLoading(false);
+      });
+
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [eventId]);
 
   if (isLoading) {
     return <div>Loading signups...</div>;

--- a/components/admin/FormSchemaForm.tsx
+++ b/components/admin/FormSchemaForm.tsx
@@ -15,7 +15,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/hooks/use-toast";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 import { z } from "zod";
 import { FormFieldsEditor } from "./FormFieldsEditor";
 import { Loader2, PlusCircle, Trash2 } from "lucide-react";
@@ -111,6 +111,8 @@ export function FormSchemaForm({
       terms: defaultValues?.terms || [],
     },
   });
+  const fields = useWatch({ control: form.control, name: "fields" });
+  const terms = useWatch({ control: form.control, name: "terms" });
 
   const onSubmit = async (data: FormSchemaData) => {
     try {
@@ -212,7 +214,7 @@ export function FormSchemaForm({
 
             <div className="mt-6 pt-6 border-t">
               <FormFieldsEditor
-                value={form.watch("fields") as unknown as FormField[]}
+                value={fields as FormField[]}
                 onChange={(fields) => form.setValue("fields", fields)}
               />
             </div>
@@ -228,7 +230,7 @@ export function FormSchemaForm({
                 </div>
 
                 <div className="space-y-4">
-                  {form.watch("terms").map((term, index) => (
+                  {terms.map((term, index) => (
                     <Card key={term.id} className="p-4">
                       <div className="flex items-start gap-4">
                         <div className="flex-1">

--- a/components/admin/FormSchemaList.tsx
+++ b/components/admin/FormSchemaList.tsx
@@ -69,8 +69,32 @@ export function FormSchemaList() {
   }, [toast]);
 
   useEffect(() => {
-    fetchSchemas();
-  }, [fetchSchemas]);
+    const controller = new AbortController();
+    let active = true;
+    fetch("/api/admin/form-schemas", { signal: controller.signal })
+      .then((response) => {
+        if (!response.ok) throw new Error("Failed to fetch schemas");
+        return response.json();
+      })
+      .then((data) => {
+        if (active) setSchemas(data);
+      })
+      .catch((error) => {
+        if (error.name !== "AbortError") {
+          console.error("Error fetching schemas:", error);
+          toast({
+            title: "Error",
+            description: "Failed to load form schemas",
+            variant: "destructive",
+          });
+        }
+      });
+
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [toast]);
 
   const handleDelete = async () => {
     if (!selectedSchema) return;

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "next": "^16.2.6",
     "next-themes": "^0.4.6",
     "node-fetch": "^3.3.2",
-    "nodemailer": "^8.0.4",
+    "nodemailer": "^9.0.1",
     "pg": "^8.21.0",
     "react": "^19.2.6",
     "react-day-picker": "^9.14.0",

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,9 @@
   "extends": [
     "github>t-scheiber/renovate-config"
   ],
-  "dependencyDashboardTitle": "Renovate Dashboard"
+  "dependencyDashboardTitle": "Renovate Dashboard",
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "enabled": false
+  }
 }

--- a/translations/initial-translations.ts
+++ b/translations/initial-translations.ts
@@ -4,8 +4,7 @@ import enTranslations from "@/translations/en.json";
 
 // Create initial translations with only English (default language)
 // Other languages will be loaded dynamically when needed
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const allTranslations: any = {
+const allTranslations: unknown = {
   en: enTranslations,
 };
 


### PR DESCRIPTION
## What changed

- Upgrade Nodemailer from 8.0.4 to 9.0.1, fixing high-severity GHSA-p6gq-j5cr-w38f.
- Use OSV-backed Renovate security checks for this repository while GitHub Dependabot security updates remain enabled.
- Replace effect-driven synchronous state updates with abortable asynchronous fetch flows.
- Replace React Hook Form watch calls with useWatch and remove the obsolete lint suppression.

## Validation

- Bun/ESLint: clean, zero warnings.
- Next.js production build: passed.
- Renovate configuration: validated against Renovate 43.246.1.